### PR TITLE
Add phase 3 structural sub-clustering pipeline

### DIFF
--- a/pipelines/phase3_structures.py
+++ b/pipelines/phase3_structures.py
@@ -1,0 +1,296 @@
+"""Phase 3 – structural sub-clustering."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import click
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd
+except Exception:  # pragma: no cover - allow CLI helpers to signal requirement
+    pd = None  # type: ignore[assignment]
+
+from indices.build_ann import build_hnsw
+from utils.hashing import blake3_hexdigest
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class StructureFeature:
+    """Light-weight container for structure level fingerprints."""
+
+    rxn_vid: int
+    cid: str
+    mid: str
+    scaffold_key: str
+    bits: set[int]
+    canopy_id: str | None = None
+    sid: str | None = None
+
+    def to_record(self) -> dict[str, object]:
+        """Serialise the feature for tabular storage."""
+
+        return {
+            "rxn_vid": self.rxn_vid,
+            "CID": self.cid,
+            "MID": self.mid,
+            "SID": self.sid,
+            "canopy_id": self.canopy_id,
+            "scaffold_key": self.scaffold_key,
+            "fingerprint_bits": json.dumps(sorted(self.bits)),
+        }
+
+    @property
+    def vector(self) -> list[float]:
+        """Return a deterministic dense representation for ANN building."""
+
+        return [float(bit) for bit in sorted(self.bits)]
+
+
+@dataclass
+class StructureCluster:
+    """Simple structural cluster description."""
+
+    cid: str
+    mid: str
+    sid: str
+    rxn_vids: list[int]
+    exemplars: list[int]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "CID": self.cid,
+            "MID": self.mid,
+            "SID": self.sid,
+            "rxn_vids": json.dumps(self.rxn_vids),
+            "exemplar_vids": json.dumps(self.exemplars),
+            "cluster_size": len(self.rxn_vids),
+        }
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(name)s - %(message)s")
+
+
+def _require_pandas() -> object:
+    if pd is None:
+        raise click.ClickException(
+            "pandas is required for file IO operations in phase3; install pandas to continue"
+        )
+    return pd
+
+
+def _loads_list(value: object | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return [text]
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+        return [str(parsed)]
+    return [str(value)]
+
+
+def _normalise_identifier(row: dict[str, object], *candidates: str, default: str) -> str:
+    for candidate in candidates:
+        value = row.get(candidate)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return default
+
+
+def _hash_token_to_bit(token: str, fp_bits: int) -> int:
+    digest = blake3_hexdigest(token.encode("utf-8"))
+    return int(digest[:8], 16) % max(fp_bits, 1)
+
+
+def _build_structure_feature(row: dict[str, object], fp_bits: int = 128) -> StructureFeature:
+    rxn_vid = int(row["rxn_vid"])
+    cid = _normalise_identifier(row, "CID", "cid", "cond_hash", default="unknown")
+    mid = _normalise_identifier(row, "MID", "mid", "cluster_id", default="unknown")
+    scaffold_key = _normalise_identifier(row, "scaffold_key", default="unknown")
+
+    tokens: set[str] = {f"scaffold:{scaffold_key}"}
+    mech_sig_base = row.get("mech_sig_base")
+    if mech_sig_base:
+        tokens.add(f"mech:{mech_sig_base}")
+    for token in _loads_list(row.get("event_tokens")):
+        tokens.add(f"event:{token}")
+
+    bits = {_hash_token_to_bit(token, fp_bits) for token in tokens}
+
+    return StructureFeature(rxn_vid=rxn_vid, cid=cid, mid=mid, scaffold_key=scaffold_key, bits=bits)
+
+
+def _tanimoto(a: Sequence[int] | set[int], b: Sequence[int] | set[int]) -> float:
+    set_a = set(a)
+    set_b = set(b)
+    if not set_a and not set_b:
+        return 1.0
+    if not set_a or not set_b:
+        return 0.0
+    intersection = len(set_a & set_b)
+    union = len(set_a | set_b)
+    if union == 0:
+        return 0.0
+    return intersection / union
+
+
+def _build_canopies(features: list[StructureFeature], tanimoto_threshold: float) -> list[list[StructureFeature]]:
+    remaining = list(features)
+    canopies: list[list[StructureFeature]] = []
+    while remaining:
+        seed = remaining.pop(0)
+        canopy_id = f"{seed.mid}-C{len(canopies) + 1}"
+        seed.canopy_id = canopy_id
+        members = [seed]
+        still_pending: list[StructureFeature] = []
+        for feature in remaining:
+            if _tanimoto(seed.bits, feature.bits) >= tanimoto_threshold:
+                feature.canopy_id = canopy_id
+                members.append(feature)
+            else:
+                still_pending.append(feature)
+        remaining = still_pending
+        canopies.append(members)
+    return canopies
+
+
+def _assign_structure_clusters(
+    features: Iterable[StructureFeature],
+    tanimoto_threshold: float,
+) -> list[StructureCluster]:
+    by_group: dict[tuple[str, str], list[StructureFeature]] = {}
+    for feature in features:
+        by_group.setdefault((feature.cid, feature.mid), []).append(feature)
+
+    clusters: list[StructureCluster] = []
+    for (cid, mid), members in sorted(by_group.items()):
+        canopies = _build_canopies(sorted(members, key=lambda f: f.rxn_vid), tanimoto_threshold)
+        for idx, canopy in enumerate(canopies, start=1):
+            sid = f"{mid}-S{idx}"
+            rxn_vids = [feature.rxn_vid for feature in canopy]
+            for feature in canopy:
+                feature.sid = sid
+            exemplars = rxn_vids[: min(3, len(rxn_vids))]
+            clusters.append(
+                StructureCluster(
+                    cid=cid,
+                    mid=mid,
+                    sid=sid,
+                    rxn_vids=rxn_vids,
+                    exemplars=exemplars,
+                )
+            )
+    return clusters
+
+
+def _write_parquet(records: list[dict[str, object]], path: Path) -> None:
+    pandas = _require_pandas()
+    frame = pandas.DataFrame(records)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_parquet(path, index=False)
+
+
+def _build_ann_indices(
+    features: Iterable[StructureFeature],
+    output_dir: Path,
+    m: int = 32,
+    efc: int = 400,
+) -> None:
+    index_dir = output_dir / "indices"
+    index_dir.mkdir(parents=True, exist_ok=True)
+    by_group: dict[tuple[str, str], list[StructureFeature]] = {}
+    for feature in features:
+        by_group.setdefault((feature.cid, feature.mid), []).append(feature)
+
+    for (cid, mid), members in sorted(by_group.items()):
+        vectors = [feature.vector for feature in members]
+        index = build_hnsw(vectors, m=m, efc=efc)
+        payload = {"cid": cid, "mid": mid, "size": len(vectors), "m": index.m, "efc": index.efc}
+        target = index_dir / f"index_{cid}_{mid}.json"
+        target.write_text(json.dumps(payload, sort_keys=True, indent=2))
+
+
+@click.command()
+@click.option("--mechanism-sigs", "mechanism_path", required=True, type=click.Path(exists=True, dir_okay=False))
+@click.option("--clusters-level2", "clusters_path", required=True, type=click.Path(exists=True, dir_okay=False))
+@click.option("--output-dir", "output_dir", required=True, type=click.Path(file_okay=False))
+@click.option("--sample", is_flag=True, help="Process only a sample of rows for smoke tests.")
+@click.option("--fp-bits", default=128, show_default=True, type=int)
+@click.option("--canopy-threshold", default=0.6, show_default=True, type=float)
+@click.option("--verbose/--quiet", default=False, show_default=True)
+def main(
+    mechanism_path: str,
+    clusters_path: str,
+    output_dir: str,
+    sample: bool,
+    fp_bits: int,
+    canopy_threshold: float,
+    verbose: bool,
+) -> None:
+    """CLI entry point for the structural clustering phase."""
+
+    _configure_logging(verbose)
+    pandas = _require_pandas()
+
+    LOGGER.info("Loading mechanism signatures from %s", mechanism_path)
+    mechanisms = pandas.read_parquet(mechanism_path)
+    LOGGER.info("Loading level 2 clusters from %s", clusters_path)
+    clusters = pandas.read_parquet(clusters_path)
+
+    if sample:
+        LOGGER.info("Sampling first 1000 rows for quick iteration")
+        mechanisms = mechanisms.head(1000)
+        clusters = clusters.head(1000)
+
+    LOGGER.info("Joining tables on rxn_vid")
+    merged = clusters.merge(mechanisms, on="rxn_vid", how="inner", suffixes=("_lvl2", "_sig"))
+    LOGGER.info("Computing structure features for %d reactions", len(merged))
+
+    features = [
+        _build_structure_feature(row, fp_bits=fp_bits)
+        for row in merged.to_dict(orient="records")
+    ]
+
+    LOGGER.info("Assigning structural clusters using Tanimoto canopy threshold %.2f", canopy_threshold)
+    clusters_lvl3 = _assign_structure_clusters(features, tanimoto_threshold=canopy_threshold)
+
+    output_dir_path = Path(output_dir)
+    features_path = output_dir_path / "structure_feats.parquet"
+    clusters_path_lvl3 = output_dir_path / "clusters_level3.parquet"
+
+    LOGGER.info("Writing %d structure features to %s", len(features), features_path)
+    _write_parquet([feature.to_record() for feature in features], features_path)
+
+    LOGGER.info("Writing %d structural clusters to %s", len(clusters_lvl3), clusters_path_lvl3)
+    _write_parquet([cluster.to_dict() for cluster in clusters_lvl3], clusters_path_lvl3)
+
+    LOGGER.info("Building ANN indices for %d groups", len({(f.cid, f.mid) for f in features}))
+    _build_ann_indices(features, output_dir_path)
+
+    success_flag = output_dir_path / "_SUCCESS"
+    success_flag.parent.mkdir(parents=True, exist_ok=True)
+    success_flag.write_text("phase3 completed\n")
+    LOGGER.info("Wrote success sentinel to %s", success_flag)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_phase3.py
+++ b/tests/test_phase3.py
@@ -1,0 +1,63 @@
+import json
+
+from pipelines.phase3_structures import (
+    StructureFeature,
+    _assign_structure_clusters,
+    _build_structure_feature,
+    _tanimoto,
+)
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    base = {
+        "rxn_vid": overrides.get("rxn_vid", 1),
+        "CID": overrides.get("CID", "cid-1"),
+        "MID": overrides.get("MID", "mid-1"),
+        "scaffold_key": overrides.get("scaffold_key", "Scaffold"),
+        "mech_sig_base": overrides.get("mech_sig_base", "base"),
+        "event_tokens": json.dumps(overrides.get("event_tokens", ["tokA"])),
+    }
+    base.update(overrides)
+    return base
+
+
+def test_structure_feature_uses_scaffold_and_events():
+    feature_a = _build_structure_feature(_row(rxn_vid=1), fp_bits=32)
+    feature_b = _build_structure_feature(_row(rxn_vid=2), fp_bits=32)
+    assert feature_a.scaffold_key == "Scaffold"
+    assert feature_a.bits == feature_b.bits
+    assert feature_a.vector == [float(bit) for bit in sorted(feature_a.bits)]
+
+
+def test_tanimoto_similarity_respects_shared_bits():
+    feature = StructureFeature(rxn_vid=1, cid="c", mid="m", scaffold_key="a", bits={1, 2, 3})
+    other = StructureFeature(rxn_vid=2, cid="c", mid="m", scaffold_key="b", bits={1, 2, 4})
+    disjoint = StructureFeature(rxn_vid=3, cid="c", mid="m", scaffold_key="c", bits={7})
+    assert _tanimoto(feature.bits, other.bits) >= 0.5
+    assert _tanimoto(feature.bits, disjoint.bits) == 0.0
+
+
+def test_assign_structure_clusters_groups_similar_canopies():
+    rows = [
+        _row(rxn_vid=1, event_tokens=["tokA", "tokB"]),
+        _row(rxn_vid=2, event_tokens=["tokA", "tokB"]),
+        _row(rxn_vid=3, event_tokens=["tokZ"], MID="mid-2"),
+        _row(rxn_vid=4, event_tokens=["tokB", "tokC"]),
+    ]
+    features = [_build_structure_feature(row, fp_bits=64) for row in rows]
+    clusters = _assign_structure_clusters(features, tanimoto_threshold=0.5)
+    assert len(clusters) == 2
+
+    # first two rows should share the same SID because of identical fingerprints
+    sid_first = next(feature.sid for feature in features if feature.rxn_vid == 1)
+    sid_second = next(feature.sid for feature in features if feature.rxn_vid == 2)
+    assert sid_first == sid_second
+
+    # row 3 belongs to a different MID, hence its own cluster
+    sid_third = next(feature.sid for feature in features if feature.rxn_vid == 3)
+    assert sid_third.startswith("mid-2-")
+
+    # verify cluster dictionary payload is sorted and exemplar limited to 3 entries
+    payload = next(cluster.to_dict() for cluster in clusters if cluster.sid == sid_first)
+    assert json.loads(payload["rxn_vids"]) == [1, 2, 4]
+    assert json.loads(payload["exemplar_vids"]) == [1, 2, 4]


### PR DESCRIPTION
## Summary
- implement the phase 3 structural clustering pipeline with feature extraction, canopy grouping, and ANN index materialisation
- add unit tests covering feature generation, Tanimoto similarity, and structural cluster assignment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9e4a69610832abce8a8918bb01a0c