### PR TITLE
Add coarse mechanism clustering buckets

### DIFF
--- a/structures/__init__.py
+++ b/structures/__init__.py
@@ -1,4 +1,4 @@
 """Structural helper utilities."""
-from .scaffold import main_scaffold  # noqa: F401
+from .scaffold import coarse_scaffold_family, main_scaffold  # noqa: F401
 
-__all__ = ["main_scaffold"]
+__all__ = ["main_scaffold", "coarse_scaffold_family"]

--- a/structures/scaffold.py
+++ b/structures/scaffold.py
@@ -1,7 +1,40 @@
 """Simplified scaffold extraction helpers."""
 from __future__ import annotations
 
+import re
 from typing import Iterable
+
+_METAL_ELEMENTS = {
+    "Li",
+    "Na",
+    "K",
+    "Mg",
+    "Al",
+    "Ti",
+    "Cr",
+    "Mn",
+    "Fe",
+    "Co",
+    "Ni",
+    "Cu",
+    "Zn",
+    "Ga",
+    "Ge",
+    "As",
+    "Se",
+    "Ru",
+    "Rh",
+    "Pd",
+    "Ag",
+    "Cd",
+    "Sn",
+    "Sb",
+    "Te",
+    "Pt",
+    "Au",
+    "Hg",
+    "Pb",
+}
 
 
 def _select_candidate(reactants: Iterable[str]) -> str | None:
@@ -21,3 +54,44 @@ def main_scaffold(reactants: list[str], products: list[str], role_info: dict | N
             return primary.strip()
     candidate = _select_candidate(reactants) or _select_candidate(products)
     return candidate or "unknown"
+
+
+def coarse_scaffold_family(scaffold_key: str) -> str:
+    """Map a raw scaffold key to a coarse structural family."""
+
+    text = (scaffold_key or "").strip()
+    if not text or text.lower() == "unknown":
+        return "unknown"
+
+    # Split multi-fragment entries into a dedicated bucket – these tend to be
+    # mixture-like scaffolds rather than a single motif.
+    if "." in text:
+        return "multi_fragment"
+
+    # Organometallic complexes typically encode the metal in brackets.
+    bracketed = re.findall(r"\[([A-Z][a-z]?)", text)
+    if any(element in _METAL_ELEMENTS for element in bracketed):
+        return "organometallic"
+
+    lowered = text.lower()
+
+    # Aromatic scaffolds commonly include lowercase aromatic carbons followed by
+    # ring indices. Require both to avoid false positives on arbitrary strings.
+    aromatic = any(f"c{digit}" in lowered for digit in "123456789")
+    hetero_aromatic = aromatic and any(char in lowered for char in "nosp")
+
+    if aromatic:
+        return "aromatic_hetero" if hetero_aromatic else "aromatic"
+
+    hetero_upper = any(symbol in text for symbol in ("N", "O", "S", "P", "F", "Cl", "Br", "I"))
+    hetero_lower = any(char in lowered for char in ("n", "o", "s", "p"))
+
+    has_carbon = "C" in text
+
+    if has_carbon:
+        return "aliphatic_hetero" if (hetero_upper or hetero_lower) else "aliphatic"
+
+    if hetero_upper or hetero_lower:
+        return "hetero_only"
+
+    return "inorganic"

--- a/tests/test_phase2.py
+++ b/tests/test_phase2.py
@@ -3,6 +3,7 @@ import json
 from pipelines.phase2_mechanism import (
     MechanismSignature,
     _cluster_signatures,
+    _coarse_mechanism_key,
     _compute_signature_payload,
 )
 
@@ -24,6 +25,7 @@ def test_compute_signature_prefers_mapped_branch():
     assert signature.signature_type == "mapped"
     assert signature.event_tokens
     assert signature.scaffold_key == "CCO"
+    assert signature.coarse_key is not None
 
 
 def test_compute_signature_falls_back_when_delta_missing():
@@ -49,8 +51,50 @@ def test_cluster_assignment_groups_by_cond_and_signature():
     assert len(clusters) == 2
     first = next(cluster for cluster in clusters if cluster.cond_hash == "hash1")
     assert json.loads(first.to_dict()["rxn_vids"]) == [1, 2]
+    base_counts = json.loads(first.to_dict()["mech_sig_base_counts"])
+    assert sum(base_counts.values()) == 2
     assert sig_a.cluster_id == first.cluster_id
     assert sig_b.cluster_id == first.cluster_id
     second = next(cluster for cluster in clusters if cluster.cond_hash == "hash2")
     assert json.loads(second.to_dict()["rxn_vids"]) == [3]
     assert sig_c.cluster_id == second.cluster_id
+
+
+def test_cluster_coalesces_by_coarse_key():
+    sig_a = MechanismSignature(
+        rxn_vid=10,
+        cond_hash="cond",
+        mech_sig_base="base_a",
+        mech_sig_r1=None,
+        mech_sig_r2=None,
+        signature_type="mapped",
+        event_tokens=["alpha:x"],
+        redox_events=0,
+        stereo_events=0,
+        ring_events=0,
+        scaffold_key="Scaf",
+    )
+    sig_a.coarse_key = _coarse_mechanism_key(sig_a)
+
+    sig_b = MechanismSignature(
+        rxn_vid=11,
+        cond_hash="cond",
+        mech_sig_base="base_b",
+        mech_sig_r1=None,
+        mech_sig_r2=None,
+        signature_type="mapped",
+        event_tokens=["alpha:y"],
+        redox_events=0,
+        stereo_events=0,
+        ring_events=0,
+        scaffold_key="Scaf",
+    )
+    sig_b.coarse_key = _coarse_mechanism_key(sig_b)
+
+    clusters = _cluster_signatures([sig_a, sig_b])
+    assert len(clusters) == 1
+    cluster = clusters[0]
+    assert json.loads(cluster.to_dict()["rxn_vids"]) == [10, 11]
+    assert sig_a.cluster_id == cluster.cluster_id == sig_b.cluster_id
+    base_counts = json.loads(cluster.to_dict()["mech_sig_base_counts"])
+    assert base_counts == {"base_a": 1, "base_b": 1}


### PR DESCRIPTION
## Summary
- derive a coarse mechanism key from scaffold and event family buckets for each signature
- regroup level 2 clusters by condition hash and coarse key while retaining raw signature base counts and hashes
- surface coarse clustering metrics in logging and extend phase 2 tests to cover the new behavior

## Testing
- pytest tests/test_phase2.py

------
https://chatgpt.com/codex/tasks/task_e_68de91d3ce08832aa31ca47aa185a507