### PR TITLE
Fix mechanism base resolution in structure phase

### DIFF
--- a/pipelines/phase3_structures.py
+++ b/pipelines/phase3_structures.py
@@ -219,7 +219,11 @@ def _structure_components(
 
     tokens: set[str] = {f"scaffold:{scaffold_key}"}
 
-    mech_sig_val = row.get("mech_sig_base")
+    mech_sig_val = _resolve_with_suffixes(
+        row,
+        "mech_sig_base",
+        suffixes=("_sig", "_lvl2", ""),
+    )
     mech_sig_base: str | None
     if mech_sig_val is None:
         mech_sig_base = None


### PR DESCRIPTION
## Summary
- ensure structure feature builder resolves `mech_sig_base` via `_resolve_with_suffixes`, preferring mechanism signatures
- normalise the resolved mechanism base before adding the fingerprint token so shared bits are restored

## Testing
- pytest tests/test_phase3.py


------
https://chatgpt.com/codex/tasks/task_e_68deb7dfff2c832ab989a18ee141f704